### PR TITLE
Add random CGFloat generation

### DIFF
--- a/Randomizable/Randomizable.swift
+++ b/Randomizable/Randomizable.swift
@@ -19,6 +19,12 @@ extension Int: Randomizable {
     }
 }
 
+extension CGFloat: Randomizable {
+    public static var random: CGFloat {
+        return .random(in: -.greatestFiniteMagnitude / 2.0 ... .greatestFiniteMagnitude / 2.0)
+    }
+}
+
 extension String: Randomizable {
     public static var random: String {
         return "\(Int.random)"

--- a/RandomizableTests/RandomizableTests.swift
+++ b/RandomizableTests/RandomizableTests.swift
@@ -14,6 +14,10 @@ class RandomizableTests: XCTestCase {
     func testRandomizedIntegersAreDifferent() {
         assertItemsAreRandom(Int.self)
     }
+
+    func testRandomizedCGFloatsAreDifferent() {
+        assertItemsAreRandom(CGFloat.self)
+    }
     
     func testRandomizedStringsAreDifferent() {
         assertItemsAreRandom(String.self)

--- a/RandomizableTests/RandomizableTests.swift
+++ b/RandomizableTests/RandomizableTests.swift
@@ -16,6 +16,8 @@ class RandomizableTests: XCTestCase {
     }
 
     func testRandomizedCGFloatsAreDifferent() {
+        // The reason for dividing `.greatestFiniteMagnitude` by 2 is because of a compiler limitation (bug?)
+        // More info here: https://github.com/apple/swift/blob/master/stdlib/public/core/FloatingPoint.swift#L2056
         assertItemsAreRandom(CGFloat.self)
     }
     


### PR DESCRIPTION
The reason why I divide `. greatestFiniteMagnitude ` by 2 is because of a compiler limitation (bug?).

More info here: https://github.com/apple/swift/blob/master/stdlib/public/core/FloatingPoint.swift#L2056